### PR TITLE
fix(routing): un-retire /games routes

### DIFF
--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -2,7 +2,6 @@ import { NextResponse, type NextRequest } from "next/server";
 import { updateSession } from "@/lib/pocketbase/middleware";
 
 const retiredPagePrefixes = [
-  "/games",
   "/calendar",
   "/chips",
   "/leaderboard",


### PR DESCRIPTION
## Summary
- `/games` (and its subroutes `/games/today`, `/games/mars`) was in `retiredPagePrefixes` in `middleware.ts` alongside genuinely retired secondary features, redirecting every game request straight to `/`.
- Production currently has no reachable way to play a game at all (`/play` also 404s).
- This removes just `/games` from the retirement list — the other seven retired prefixes (calendar, chips, leaderboard, discuss, profile, postcards, source) are untouched.

Found while working the `tdt-non-negotiable-minimum-2026-07-18` floor ticket ("puzzles ready to go").

## Test plan
- [x] `npm run build` clean, `/games`, `/games/mars`, `/games/today` present in the route manifest
- [x] Verified locally: `curl localhost:3001/games/today` -> 200 (was previously redirecting via this middleware rule)
- [ ] Confirm real anomaly data is seeded so `/games/today` shows a real puzzle, not an empty state (separate follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)